### PR TITLE
Add extdiff as default diff support

### DIFF
--- a/eden/scm/sapling/cmdutil.py
+++ b/eden/scm/sapling/cmdutil.py
@@ -2047,6 +2047,17 @@ def diffordiffstat(
     hunksfilterfn=None,
 ):
     """show diff or diffstat."""
+    if diffopts.extdiffcmd and not stat:
+        from .ext import extdiff as _extdiff
+        cmdline = diffopts.extdiffcmd
+        if diffopts.extdiffopts:
+            cmdline += " " + " ".join(map(util.shellquote, diffopts.extdiffopts))
+        opts = {
+            "rev": [str(ctx1.rev()), str(ctx2.rev())],
+            "patch": False,
+        }
+        _extdiff.dodiff(ui, repo, cmdline, list(match.files()), opts)
+        return
     if fp is None:
         if stat:
             write = ui.write

--- a/eden/scm/sapling/mdiff.py
+++ b/eden/scm/sapling/mdiff.py
@@ -88,6 +88,8 @@ class diffopts:
         "worddiff": False,
         "hashbinary": False,
         "filtercopysource": False,
+        "extdiffcmd": "",
+        "extdiffopts": [],
     }
 
     def __init__(self, **opts):

--- a/eden/scm/sapling/patch.py
+++ b/eden/scm/sapling/patch.py
@@ -2571,6 +2571,8 @@ def difffeatureopts(
 
     buildopts["hashbinary"] = ui.configbool("diff", "hashbinary")
     buildopts["filtercopysource"] = ui.configbool("diff", "filtercopysource")
+    buildopts["extdiffcmd"] = ui.config("ui", "extdiffcmd")
+    buildopts["extdiffopts"] = ui.configlist("ui", "extdiffopts")
     if whitespace:
         buildopts["ignorews"] = get("ignore_all_space", "ignorews")
         buildopts["ignorewsamount"] = get("ignore_space_change", "ignorewsamount")

--- a/eden/scm/tests/test-default-extdiff.t
+++ b/eden/scm/tests/test-default-extdiff.t
@@ -1,0 +1,24 @@
+#require diff echo no-eden
+
+  $ enable extdiff
+  $ setconfig ui.extdiffcmd "echo DIFF"
+
+  $ hg init repo
+  $ cd repo
+  $ echo a > a
+  $ hg add a
+  $ hg commit -m base -d '0 0'
+  $ echo b >> a
+
+  $ sl diff
+  DIFF * * (glob)
+  [1]
+
+  $ sl show
+  DIFF * * (glob)
+  [1]
+
+  $ sl log -p -r .
+  changeset:   0:* (glob)
+  DIFF * * (glob)
+  [1]


### PR DESCRIPTION
## Summary
- extend diff options to recognize an external diff command
- expose the new config via diff option builder
- if configured, use extdiff for `sl diff`, `sl log -p` and `sl show`
- regression test demonstrating default extdiff usage

## Testing
- `python -m py_compile sapling/mdiff.py sapling/patch.py sapling/cmdutil.py`
- `./run-tests.py test-default-extdiff.t` *(fails: --local specified, but sl or hg not found)*

------
https://chatgpt.com/codex/tasks/task_i_684085d70100832697e1e6c67f0d106b