### PR TITLE
Add extdiff as default diff option

### DIFF
--- a/eden/scm/sapling/cmdutil.py
+++ b/eden/scm/sapling/cmdutil.py
@@ -1911,6 +1911,23 @@ def diffordiffstat(
     hunksfilterfn=None,
 ):
     """show diff or diffstat."""
+    exttool = ui.config("diff", "tool")
+    if exttool and not stat:
+        from sapling.ext import extdiff
+
+        if not extdiff.cmdtable:
+            raise error.Abort(_("extdiff plugin not enabled"))
+
+        if exttool not in extdiff.cmdtable:
+            raise error.Abort(_("unknown extdiff tool '%s'") % exttool)
+
+        opts = {
+            "rev": [str(ctx1.rev()), str(ctx2.rev())],
+            "option": [],
+        }
+
+        extdiff.cmdtable[exttool][0](ui, repo, *list(match.files()), **opts)
+        return
     if fp is None:
         if stat:
             write = ui.write


### PR DESCRIPTION
## Summary
- use extdiff commands when `[diff] tool` is configured
- default `sl diff`, `sl show`, and `sl log -p` to extdiff if available

## Testing
- `python3 eden/scm/tests/run-tests.py -h`
- `python3 eden/scm/tests/run-tests.py -j2 eden/scm/tests/test-extdiff.t` *(fails: sl or hg not found)*

------
https://chatgpt.com/codex/tasks/task_i_68851d4c93048326ba72caa999ce3c01